### PR TITLE
Colocate data fetching; use proper server components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "ai": "^3.0.13",
         "clsx": "^1.2.1",
         "openai": "^4.29.0",
-        "react": "^18.3.0-canary-a870b2d54-20240314",
-        "react-dom": "^18.3.0-canary-a870b2d54-20240314",
+        "react": "^19.0.0-canary-7a2609eed-20240403",
+        "react-dom": "^19.0.0-canary-7a2609eed-20240403",
         "react-markdown": "^9.0.1",
-        "react-server-dom-webpack": "^18.3.0-canary-a870b2d54-20240314",
+        "react-server-dom-webpack": "^19.0.0-canary-7a2609eed-20240403",
         "react-textarea-autosize": "^8.5.3",
         "server-only": "^0.0.1",
         "zod": "^3.22.4"
@@ -7677,22 +7677,22 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.0-canary-a870b2d54-20240314",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.0-canary-a870b2d54-20240314.tgz",
-      "integrity": "sha512-/sjBAVN6TJ1G+Ia3hGMaLGZE3w/OKtO6FEzz/wBUKdmK3obyJvxK0FmHGVPpM9nDzrw5f1WJDoPE8nGgkvpKog==",
+      "version": "19.0.0-canary-7a2609eed-20240403",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0-canary-7a2609eed-20240403.tgz",
+      "integrity": "sha512-v3YYaKzyYTki2NbM5Xs/1XPy/XRGtC2ljiqL97Zgo0Iu3jBTsH0k8pJ3h2gFP8F6hudik32mb3l4fG4GfVKieA==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.0-canary-a870b2d54-20240314",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.0-canary-a870b2d54-20240314.tgz",
-      "integrity": "sha512-m56pjWn6kmg0M4GLxtC8A+Uh1AVIc+IESfi1mV810nCoHdMcO/tmhC6pIaWtxHBb3szP0x0p+BXF42nf8lKkVA==",
+      "version": "19.0.0-canary-7a2609eed-20240403",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-canary-7a2609eed-20240403.tgz",
+      "integrity": "sha512-8bn+CmtnyFNFBOATBwmQRm/6G8iu2/RT0AYoTJZNPLof7MggHPHh9USpbEqEozc3M/KnDC7ebR21q9E6GEQX0A==",
       "dependencies": {
-        "scheduler": "0.24.0-canary-a870b2d54-20240314"
+        "scheduler": "0.25.0-canary-7a2609eed-20240403"
       },
       "peerDependencies": {
-        "react": "18.3.0-canary-a870b2d54-20240314"
+        "react": "19.0.0-canary-7a2609eed-20240403"
       }
     },
     "node_modules/react-markdown": {
@@ -7721,9 +7721,9 @@
       }
     },
     "node_modules/react-server-dom-webpack": {
-      "version": "18.3.0-canary-a870b2d54-20240314",
-      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-18.3.0-canary-a870b2d54-20240314.tgz",
-      "integrity": "sha512-kIIvAvJ5QX/YNVpFTfQkojkqt/KzUStFyJ+r/m7i1d29EWZe7vQ3AJmCljvf6jORg3yitRmVMs/rFapQ9t9mtQ==",
+      "version": "19.0.0-canary-7a2609eed-20240403",
+      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-19.0.0-canary-7a2609eed-20240403.tgz",
+      "integrity": "sha512-1PkUQ1BwYd5GfYRL4taJ0QgzENZTjcbcnJAcUVtNWIrjmkF792h/w12NiJ1frCa346EYlGjJ4VVaaDKiMHbeug==",
       "dependencies": {
         "acorn-loose": "^8.3.0",
         "neo-async": "^2.6.1"
@@ -7732,8 +7732,8 @@
         "node": ">=0.10.0"
       },
       "peerDependencies": {
-        "react": "18.3.0-canary-a870b2d54-20240314",
-        "react-dom": "18.3.0-canary-a870b2d54-20240314",
+        "react": "19.0.0-canary-7a2609eed-20240403",
+        "react-dom": "19.0.0-canary-7a2609eed-20240403",
         "webpack": "^5.59.0"
       }
     },
@@ -8082,9 +8082,9 @@
       "dev": true
     },
     "node_modules/scheduler": {
-      "version": "0.24.0-canary-a870b2d54-20240314",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.24.0-canary-a870b2d54-20240314.tgz",
-      "integrity": "sha512-HS8crSVpnKgW1ZlzEA+tahjDjLYGre5D/7d4xmYcTjGw6Lcf8Bi1xbHO5QKz3aUqKNN8+Yhde8FcsuEO82+lug=="
+      "version": "0.25.0-canary-7a2609eed-20240403",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-canary-7a2609eed-20240403.tgz",
+      "integrity": "sha512-c2LhVLIPFxw4/jY0ImVp+fsP70gak7wFm93DzHDW7c0ifaXwixShs63VjblRLhsjAmRFQeBWKyOAHCAY44XAgw=="
     },
     "node_modules/schema-utils": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "ai": "^3.0.13",
     "clsx": "^1.2.1",
     "openai": "^4.29.0",
-    "react": "^18.3.0-canary-a870b2d54-20240314",
-    "react-dom": "^18.3.0-canary-a870b2d54-20240314",
+    "react": "^19.0.0-canary-7a2609eed-20240403",
+    "react-dom": "^19.0.0-canary-7a2609eed-20240403",
     "react-markdown": "^9.0.1",
-    "react-server-dom-webpack": "^18.3.0-canary-a870b2d54-20240314",
+    "react-server-dom-webpack": "^19.0.0-canary-7a2609eed-20240403",
     "react-textarea-autosize": "^8.5.3",
     "server-only": "^0.0.1",
     "zod": "^3.22.4"

--- a/src/app/google-image-search.ts
+++ b/src/app/google-image-search.ts
@@ -2,6 +2,7 @@ import {z} from 'zod';
 
 export type Image = z.TypeOf<typeof image>;
 export type ImageSearchResponse = z.TypeOf<typeof imageSearchResponse>;
+export type ImageSearchParams = z.TypeOf<typeof imageSearchParams>;
 
 const apiKey = process.env.GOOGLE_SEARCH_API_KEY!;
 const searchEngineId = process.env.GOOGLE_SEARCH_SEARCH_ENGINE_ID!;

--- a/src/app/image-search-result.ts
+++ b/src/app/image-search-result.ts
@@ -37,13 +37,9 @@ export function createImageSearchResult(
     : {status: `found`, images: response, title};
 }
 
-export function serializeImageSearchResults(
-  imageSearchResults: ImageSearchResult[],
-): string {
-  return JSON.stringify(imageSearchResults.map(reduceImageSarchResult));
-}
-
-function reduceImageSarchResult(imageSearchResult: ImageSearchResult) {
+export function prepareImageSearchResultForAiState(
+  imageSearchResult: ImageSearchResult,
+): unknown {
   const {status, title} = imageSearchResult;
 
   if (imageSearchResult.status === `found`) {

--- a/src/app/images.tsx
+++ b/src/app/images.tsx
@@ -15,6 +15,19 @@ export interface ImagesProps {
   readonly onDataFetched: (dataForAiState: unknown) => void;
 }
 
+type ImagesContainerProps = React.PropsWithChildren<{
+  readonly title: string;
+}>;
+
+function ImagesContainer({title, children}: ImagesContainerProps) {
+  return (
+    <div className="space-y-3">
+      <h4 className="text-l font-bold">{title}</h4>
+      {children}
+    </div>
+  );
+}
+
 export async function Images({
   title,
   notFoundMessage,
@@ -40,15 +53,16 @@ export async function Images({
         : result.errorMessage;
 
     return (
-      <p className="text-sm">
-        <em>{message}</em>
-      </p>
+      <ImagesContainer title={result.title}>
+        <p className="text-sm">
+          <em>{message}</em>
+        </p>
+      </ImagesContainer>
     );
   }
 
   return (
-    <div className="space-y-3">
-      <h4 className="text-l font-bold">{result.title}</h4>
+    <ImagesContainer title={result.title}>
       {result.images.map(({thumbnailUrl, url, width, height}) => (
         <ImageSelector key={thumbnailUrl} url={url}>
           <ProgressiveImage
@@ -60,6 +74,6 @@ export async function Images({
           />
         </ImageSelector>
       ))}
-    </div>
+    </ImagesContainer>
   );
 }

--- a/src/app/images.tsx
+++ b/src/app/images.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import {type ImageSearchParams, searchImages} from './google-image-search.js';
+import {
+  createImageSearchResult,
+  prepareImageSearchResultForAiState,
+} from './image-search-result.js';
+import {ImageSelector} from './image-selector.js';
+import {ProgressiveImage} from './progressive-image.js';
+
+export interface ImagesProps {
+  readonly title: string;
+  readonly notFoundMessage: string;
+  readonly errorMessage: string;
+  readonly searchParams: ImageSearchParams;
+  readonly onDataFetched: (dataForAiState: unknown) => void;
+}
+
+export async function Images({
+  title,
+  notFoundMessage,
+  errorMessage,
+  searchParams,
+  onDataFetched,
+}: ImagesProps): Promise<React.ReactElement> {
+  const response = await searchImages(searchParams);
+
+  const result = createImageSearchResult({
+    response,
+    title,
+    notFoundMessage,
+    errorMessage,
+  });
+
+  onDataFetched(prepareImageSearchResultForAiState(result));
+
+  if (result.status !== `found`) {
+    const message =
+      result.status === `not-found`
+        ? result.notFoundMessage
+        : result.errorMessage;
+
+    return (
+      <p className="text-sm">
+        <em>{message}</em>
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h4 className="text-l font-bold">{result.title}</h4>
+      {result.images.map(({thumbnailUrl, url, width, height}) => (
+        <ImageSelector key={thumbnailUrl} url={url}>
+          <ProgressiveImage
+            thumbnailUrl={thumbnailUrl}
+            url={url}
+            width={width}
+            height={height}
+            alt={result.title}
+          />
+        </ImageSelector>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Performing all image search requests upfront, before rendering any image components, wasn't really in line with how server components should work. This approach was initially chosen to obtain a single `function` AI state that contains data from all searches.

With the introduction of the `onDataFetched` prop, we can achieve the same outcome while moving data fetching directly into the server components, where it belongs.

This change also makes it easier to add loading skeletons later on.

The approach does have the downside that we need to follow this kind of awkward rendering approach:
- map over `searches` to create pairs of elements and their data promises
- yield the elements as part of the "final UI" (but suspended)
- await all the data from the child components, and put it into the AI state
- return the final UI